### PR TITLE
Make password an init argument instead of a getpass invocation

### DIFF
--- a/vbscraper.py
+++ b/vbscraper.py
@@ -6,7 +6,6 @@
 
 import requests
 import lxml.html
-import getpass
 import bs4
 import collections
 import datetime
@@ -44,7 +43,7 @@ class VBSession(object):
         self.login_url = '/ptlweb/WebPortal?bankid={}'.format(self.bank_id)
         self.verbose = verbose
 
-    def login(self, username):
+    def login(self, username, password):
         """
         Login to Volksbank Online Banking
         """
@@ -62,7 +61,7 @@ class VBSession(object):
         # Fill in username and password
         login_data = dict(login_form.fields)
         login_data['pruefenPIN_V01_VO.strVrKennungOderAlias'] = username
-        login_data['pruefenPIN_V01_VO.txtKkdPwTrp'] = getpass.getpass()
+        login_data['pruefenPIN_V01_VO.txtKkdPwTrp'] = password
         login_data['event___login'] = 'Login'
 
         # Post login


### PR DESCRIPTION
Hi! Thanks for this, very hepful! I'm using your VB-Scraper as a library ( https://github.com/moba/GLSfetch/ ), and removed the forced getpass so I can fetch the password from a local config. 

Maybe you like the change, if not I'm not offended if you ignore or close it.