### PR TITLE
Explicitly tell BeautifulSoup to pick "best available parser"

### DIFF
--- a/vbscraper.py
+++ b/vbscraper.py
@@ -15,6 +15,7 @@ import shutil
 import os
 import os.path
 
+html_parser = "html.parser" # let BeautifulSoup choose html parser
 
 PostboxDocument = collections.namedtuple(
     'PostboxDocument',
@@ -72,7 +73,7 @@ class VBSession(object):
         )
 
         # Parse returned page
-        soup = bs4.BeautifulSoup(r.text)
+        soup = bs4.BeautifulSoup(r.text, html_parser)
 
         if not soup.find(text='Finanzstatus'):
             raise RuntimeError('Login to Volksbank Online Banking failed.')
@@ -111,7 +112,7 @@ class VBSession(object):
         r = self.s.get(self.base_url + self.postbox_url)
 
         # Parse Postbox page
-        soup = bs4.BeautifulSoup(r.text)
+        soup = bs4.BeautifulSoup(r.text, html_parser)
 
         # Get number of pages
         li = soup.find('li', attrs={'class': 'gad-paginationActivePageNumber'})
@@ -181,7 +182,7 @@ class VBSession(object):
             r = self.s.get(self.base_url + a_next_page['href'])
 
             # Parse Postbox page
-            soup = bs4.BeautifulSoup(r.text)
+            soup = bs4.BeautifulSoup(r.text, html_parser)
 
         return ret
 
@@ -197,7 +198,7 @@ class VBSession(object):
         r = self.s.get(self.base_url + self.postbox_url)
 
         # Parse Postbox page
-        soup = bs4.BeautifulSoup(r.text)
+        soup = bs4.BeautifulSoup(r.text, html_parser)
 
         # Get current page number
         li = soup.find(
@@ -227,7 +228,7 @@ class VBSession(object):
         r = self.s.get(self.base_url + document.url)
 
         # parse message page
-        soup = bs4.BeautifulSoup(r.text)
+        soup = bs4.BeautifulSoup(r.text, html_parser)
 
         #subject = msg_soup.find(
         #    'label', attrs={'for': 'messageSenderSubject'}


### PR DESCRIPTION
BeautifulSoup now spits out a warning when one does not pass an explicit parser argument. This PR removes the warning and tells BeautifulSoup to use the "best available parser". (I guess all available parsers will work in this case, but that is pure speculation.)