### PR TITLE
Fix download of attachments from messages with unicode subjects

### DIFF
--- a/vbscraper.py
+++ b/vbscraper.py
@@ -222,7 +222,7 @@ class VBSession(object):
 
         # get message page
         if self.verbose:
-            print("Download document {}".format(document.subject))
+            print(u"Download document {}".format(document.subject))
 
         r = self.s.get(self.base_url + document.url)
 


### PR DESCRIPTION
Fixes a problem with unicode subjects in messages:

```python
PostboxDocument(msg_date=datetime.datetime(2017, 10, 20, 10, 58), msg_type=u'Bankpostkorb', is_new=True, url=u'/ptlweb/WebPortal?frame=content...', subject=u'Bankpostkorb F\xfcr Ihr Unternehmen: AGB-\xc4n...', postbox_page=u'4')

Access postbox
Access postbox page 4
Traceback (most recent call last):
  File "fetch.py", line 43, in <module>
    scraper.download_document(document, [directory])
  File "vbscraper.py", line 229, in download_document
    print("Download document {}".format(document.subject))
UnicodeEncodeError: 'ascii' codec can't encode character u'\xfc' in position 14: ordinal not in range(128)
```